### PR TITLE
fix: scaling_plan_config was not effectively optional

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -3,7 +3,7 @@ data "azurerm_client_config" "current" {}
 data "azuread_service_principal" "avd_service_principal" {
   count = (
     var.scaling_plan_config.enabled && var.scaling_plan_config.role_assignment.enabled && var.scaling_plan_config.role_assignment.principal_id == null
-  ) ? 1 : 0
+  ) ? 0 : 1
 
   client_id = local.avd_service_principal_client_id
 }


### PR DESCRIPTION
Due to boolean test mismatch.

Fixes #1

Signed-off-by: Mateusz Łoskot <mateusz@loskot.net>
